### PR TITLE
Update to use Azure Text Analytics API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Trata-se de uma POC (Prova de conceito) do projeto de código-aberto do [Filipe Deschamps](https://www.youtube.com/watch?v=kjhu1LEmRpY), onde basicamente o usuário informa algum tema de pesquisa para o vídeo, depois escolhe o filtro de entrada: "Who is", "What is" ou "The history of". Onde a API de busca no Wikipedia da [Algorithmia](https://algorithmia.com/), utilizará da Machine Learning para efetuar o resumo com base no filtro escolhido anteriormente pelo usuário. 
 
-Com o resumo salvo, a próxima etapa será extrair do conteúdo, os metadados e as "keywords" com o uso da API de [Natural Language Understanding](https://www.ibm.com/br-pt/cloud/watson-natural-language-understanding) da Inteligência Artificial Watson da IBM. 
+Com o resumo salvo, a próxima etapa será extrair do conteúdo, os metadados e as "keywords" com o uso da API de [Azure Text Analytics](https://azure.microsoft.com/en-us/services/cognitive-services/text-analytics/) da Microsoft. 
 
 Após as "keywords" coletadas, serão utilizadas como base na busca das imagens, utilizando a API do Google Search/Image. Pois a ideia é lançar a imagem referenciando a legenda sobre o tema durante o vídeo.
 
@@ -27,7 +27,7 @@ Todas essas etapas: / Recolher conceito / Download Imagens / Renderização Víd
 
 Por ser uma POC, necessitará das chaves das API's utilizadas no projeto. Clicando [aqui](https://github.com/filipedeschamps/video-maker), será direcionado ao README do projeto original com os passos para configuração.
 
-Na minha adapação para ferramenta FREE, precisará das dependências:
+Na minha adaptação para ferramenta FREE, precisará das dependências:
 
 ```bash
 # Videoshow
@@ -54,9 +54,8 @@ $ npm install readline-sync
 ## Algorithmia Market Place Machine Learning
 $ npm i algorithmia
 
-# Natural Language Understanding
-$ npm i watson-developer-cloud and 
-$ npm i ibm-watson
+# Azure Text Analytics
+$ npm i azure-ai-textanalytics
 
 # Google APIs
 $ npm i googleapis

--- a/credentials/README.md
+++ b/credentials/README.md
@@ -8,17 +8,14 @@ File: `algorithmia.json`
   "apiKey": "simJ4Eko0SI4HOSLW6wCMPQWxRD1"
 }
 ```
-## Watson Natural Language Understanding
 
-File: `watson-nlu.json`
+## Azure Text Analytics API
+
+File: `azure-text-analytics.json`
 
 ```json
 {
-  "apikey": "UfX7SF2foIsqJIYv8aHkF19cWOIKvfol4iXnjZ_Bf3Fe",
-  "iam_apikey_description": "Auto-generated for key e3bd244f-4489-402b-b6f9-2ab3e2d730ce",
-  "iam_apikey_name": "Auto-generated service credentials",
-  "iam_role_crn": "crn:v1:bluemix:public:iam::::serviceRole:Manager",
-  "iam_serviceid_crn": "crn:v1:bluemix:public:iam-identity::a/6865e1cc82584796b50770aecbf0a697::serviceid:ServiceId-6ca3deed-5197-4f7c-81ac-c44c6fc72205",
-  "url": "https://api.eu-gb.natural-language-understanding.watson.cloud.ibm.com/instances/20043210-dd40-4a3c-9a73-fddacd492102"
+  "apiKey": "your-azure-text-analytics-api-key",
+  "endpoint": "your-azure-text-analytics-endpoint"
 }
 ```

--- a/package.json
+++ b/package.json
@@ -25,13 +25,12 @@
     "ffprobe": "^1.1.0",
     "gm": "^1.23.1",
     "googleapis": "^48.0.0",
-    "ibm-watson": "^5.4.0",
     "image-downloader": "^3.5.0",
     "open": "^7.0.3",
     "readline-sync": "^1.4.10",
     "sbd": "^1.0.17",
     "videoshow": "^0.1.12",
-    "watson-developer-cloud": "^4.0.1"
+    "azure-ai-textanalytics": "^5.1.0"
   },
   "devDependencies": {
     "eslint": "^7.4.0",


### PR DESCRIPTION
Update project to use Azure Text Analytics API instead of Watson.

* **credentials/README.md**
  - Add instructions for Azure Text Analytics API credentials.
  - Remove Watson Natural Language Understanding credentials section.

* **package.json**
  - Remove `ibm-watson` and `watson-developer-cloud` dependencies.
  - Add `azure-ai-textanalytics` dependency.

* **README.md**
  - Update instructions to use Azure Text Analytics API instead of Watson.
  - Update dependencies list to include `azure-ai-textanalytics`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/RBNoronha/video-maker/tree/convert-python-azure?shareId=XXXX-XXXX-XXXX-XXXX).