### PR TITLE
Customize video duration

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,11 +5,15 @@ import robots.video as video_robot
 import robots.youtube as youtube_robot
 import telegram_bot  # Import the telegram_bot.py file
 
+def get_video_duration():
+    return int(input("Enter the duration for each video clip (in seconds): "))
+
 def main():
     input_robot.run()
     text_robot.run()
     image_robot.run()
-    video_robot.run()
+    video_duration = get_video_duration()
+    video_robot.run(video_duration)
     youtube_robot.run()
     telegram_bot  # Run the Telegram bot
 

--- a/robots/input.py
+++ b/robots/input.py
@@ -12,6 +12,9 @@ def ask_and_return_prefix():
     selected_prefix_index = int(input()) - 1
     return prefixes[selected_prefix_index]
 
+def ask_and_return_video_duration():
+    return int(input("Enter the duration for each video clip (in seconds): "))
+
 def save_state(content):
     with open("state.json", "w") as file:
         json.dump(content, file)
@@ -20,6 +23,7 @@ def run():
     content = {"maximumSentences": 7}
     content["searchTerm"] = ask_and_return_search_term()
     content["prefix"] = ask_and_return_prefix()
+    content["videoDuration"] = ask_and_return_video_duration()
     save_state(content)
 
 if __name__ == "__main__":

--- a/robots/state.py
+++ b/robots/state.py
@@ -9,3 +9,7 @@ def save(content):
 def load():
     with open(content_file_path, 'r') as content_file:
         return json.load(content_file)
+
+content = load()
+content['videoDuration'] = 5  # Default duration if not specified
+save(content)

--- a/robots/video.py
+++ b/robots/video.py
@@ -37,13 +37,19 @@ def create_youtube_thumbnail():
     image = Image.open(input_file)
     image.save(output_file)
 
+def get_clip_duration(content, sentence_index):
+    if "videoDuration" in content:
+        return content["videoDuration"]
+    return 5
+
 def render_video_with_moviepy(content):
     clips = []
     for sentence_index in range(len(content["sentences"])):
         image_path = f"./content/{sentence_index}-converted.png"
         sentence_image_path = f"./content/{sentence_index}-sentence.png"
-        image_clip = mp.ImageClip(image_path).set_duration(5)
-        sentence_clip = mp.ImageClip(sentence_image_path).set_duration(5)
+        duration = get_clip_duration(content, sentence_index)
+        image_clip = mp.ImageClip(image_path).set_duration(duration)
+        sentence_clip = mp.ImageClip(sentence_image_path).set_duration(duration)
         final_clip = mp.CompositeVideoClip([image_clip, sentence_clip.set_position(("center", "bottom"))])
         clips.append(final_clip)
 


### PR DESCRIPTION
Add functionality to handle video duration input from the user and apply it to video clips.

* **robots/video.py**
  - Add `get_clip_duration` function to retrieve the duration of each clip from the content or use a default of 5 seconds.
  - Modify `render_video_with_moviepy` function to use the new `get_clip_duration` function.

* **main.py**
  - Add `get_video_duration` function to get the video duration from the user.
  - Pass the video duration to the `video_robot.run` function.

* **robots/input.py**
  - Add `ask_and_return_video_duration` function to ask the user for the video duration.
  - Save the video duration to the state.

* **robots/state.py**
  - Add a new key `videoDuration` to the content dictionary with a default value of 5 seconds.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/RBNoronha/video-maker/tree/add-rss-feed-functionality?shareId=XXXX-XXXX-XXXX-XXXX).